### PR TITLE
Fix boil throwin errors on bad input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A collection of useful and helpful functions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/array.ts
+++ b/src/array.ts
@@ -22,6 +22,7 @@ export const group = <T>(array: T[], getGropuId: (item: T) => string) => {
  * Ex. const greatest = () => boil(numbers, (a, b) => a > b)
  */
 export const boil = <T>(array: T[], compareFunc: (a: T, b: T) => T) => {
+  if (!array || (array.length ?? 0) === 0) return null
   return array.reduce(compareFunc)
 }
 

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -34,6 +34,18 @@ describe('array module', () => {
       assert.equal(result.game, 'e')
       assert.equal(result.score, 500)
     })
+    test('does not fail when provided array is empty', () => {
+      const result = _.boil([], () => true)
+      assert.isNull(result)
+    })
+    test('does not fail when provided array is null', () => {
+      const result = _.boil(null, () => true)
+      assert.isNull(result)
+    })
+    test('does not fail when provided array is funky shaped', () => {
+      const result = _.boil({} as any, () => true)
+      assert.isNull(result)
+    })
   })
 
   describe('sum function', () => {


### PR DESCRIPTION
javascript `reduce` throws an error if the given array is empty and no init acc is provided:
```js
[].reduce(() => true)
``` 
^^^ this will throw an error. So `_.boil` has been throwing errors on empty arrays. Fixed that.