### PR TITLE
More versatile list function

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -234,19 +234,24 @@ export function* range(
   }
 }
 
+type ItemOf<I extends Iterable<any>|ArrayLike<any>|number> = I extends Iterable<infer Item> ? Item : I extends ArrayLike<infer Item> ? Item : unknown;
+
 /**
- * Creates a list with numbers ranging from the
- * start to the end by the given step.
+ * Creates a list of given length or using an iterable
  *
- * @example list(0, 3) // [0, 1, 2, 3]
- * @example list(2, 10, 2) // [2, 4, 6, 8 ,10]
+ * @example list(5, {}) // [{}, {}, {}, {}, {}]
+ * @example list(range(2, 10, 2)) // [2, 4, 6, 8 ,10]
+ * @example list(range(97, 107, 2), (x) => String.fromCharCode(x)) // ['a', 'c', 'e', 'g', 'i', 'k']
  */
-export const list = (
-  start: number,
-  end: number,
-  step: number = 1
-): number[] => {
-  return Array.from(range(start, end, step))
+export const list = <I extends Iterable<any>|ArrayLike<any>|number, T>(
+  ...args: [from: I, map?: T|((v: ItemOf<I>, k: number) => T)]
+): T extends {} ? T[] : I extends number ? unknown extends T ? undefined[] : T[] : ItemOf<I>[] => {
+  const [from, map] = args;
+  const arg1 = typeof from === 'number' ? Array(from) : from as Iterable<any>;
+  if (args.length < 2) return Array.from(arg1) as any;
+
+  const arg2 = (typeof map === 'function' ? map : () => map) as (v: ItemOf<I>, k: number) => T;
+  return Array.from(arg1, arg2) as any;
 }
 
 /**

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -317,21 +317,32 @@ describe('array module', () => {
   })
   
   describe('list function', () => {
-    test('creates correct list', () => {
-      const result = _.list(0, 4)
-      assert.deepEqual(result, [0, 1, 2, 3, 4])
+    test('creates empty list of size N', () => {
+      const N = 5
+      const result = _.list(N)
+      assert.equal(result.length, N)
+      assert.isUndefined(result[0])
     })
-    test('creates correct list with step', () => {
-      const result = _.list(3, 12, 3)
-      assert.deepEqual(result, [3, 6, 9, 12])
+    test('creates list of N items', () => {
+      const N = 5
+      const value = {}
+      const result = _.list(N, value)
+      assert.deepEqual(result, [value, value, value, value, value])
     })
-    test('omits end if step does not land on it', () => {
-      const result = _.list(0, 5, 2)
-      assert.deepEqual(result, [0, 2, 4])
+    test('creates list of N items using callback', () => {
+      const N = 5
+      const result = _.list(5, () => ({}))
+      assert.equal(result.length, N)
+      result.forEach((v) => assert.isObject(v))
     })
-    test('returns start only if step larger than end', () => {
-      const result = _.list(0, 5, 20)
-      assert.deepEqual(result, [0])
+    test('creates list of N consecutive numbers using callback', () => {
+      const N = 5
+      const result = _.list(5, (_, ix) => ix + 1)
+      assert.deepEqual(result, [1, 2, 3, 4, 5])
+    })
+    test('creates list of N consecutive numbers using range', () => {
+      const result = _.list(_.range(1, 5))
+      assert.deepEqual(result, [1, 2, 3, 4, 5])
     })
   })
 


### PR DESCRIPTION
Right now the `list` function does not add a lot of value; it just wraps `range` in `Array.from`. I propose a more versatile function while maintaining strong typing. Here are some usage examples:

```js
list(5) // => [undefined, undefined, undefined, undefined, undefined]
list(5, {}) // => [{}, {}, {}, {}, {}]
list(5, Math.random) // => <random number>[5]
list(range(2, 10, 2)) // => [2, 4, 6, 8, 10]
list(range(97, 107, 2), (x) => String.fromCharCode(x)) // => ['a', 'c', 'e', 'g', 'i', 'k']
```

Array allocation has always been awkward in JavaScript compared to something like Python, and honestly, I could see myself using **radash** for this function alone, if this does get merged.