### PR TITLE
fix isEmpty test case for string class

### DIFF
--- a/src/tests/typed.test.ts
+++ b/src/tests/typed.test.ts
@@ -344,7 +344,7 @@ describe('typed module', () => {
       assert.isTrue(result)
     })
     test('returns true for empty string class', () => {
-      const input = ''
+      const input = String()
       const result = _.isEmpty(input)
       assert.isTrue(result)
     })


### PR DESCRIPTION
Hello,

Just a fix for `isEmpty` test case `'returns true for empty string class'`