### PR TITLE
extend get function to get by string path

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -176,6 +176,10 @@ export const omit = <T, TKeys extends keyof T>(
   )
 }
 
+/**
+ * Note: Passing a function has been @deprecated
+ * and will be removed in the next major version.
+ */
 export const get = <T, K>(
   value: T,
   funcOrPath: ((t: T) => K) | string,

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,4 +1,4 @@
-import { isObject } from './typed'
+import { isFunction, isObject } from './typed'
 
 /**
  * Removes (shakes out) undefined entries from an
@@ -178,14 +178,27 @@ export const omit = <T, TKeys extends keyof T>(
 
 export const get = <T, K>(
   value: T,
-  getter: (t: T) => K,
+  funcOrPath: ((t: T) => K) | string,
   defaultValue: K | null = null
-) => {
-  try {
-    return getter(value) ?? defaultValue
-  } catch {
+): K => {
+  if (value === null || value === undefined) {
     return defaultValue
   }
+  if (isFunction(funcOrPath)) {
+    try {
+      return (funcOrPath as Function)(value) ?? defaultValue
+    } catch {
+      return defaultValue
+    }
+  }
+  const segments = (funcOrPath as string).split(/[\.\[\]]/g)
+  let current: any = value
+  for (const key of segments) {
+    if (key.trim() === '') continue
+    current = current[key]
+    if (current === undefined) return defaultValue
+  }
+  return current
 }
 
 /**

--- a/src/object.ts
+++ b/src/object.ts
@@ -177,7 +177,7 @@ export const omit = <T, TKeys extends keyof T>(
 }
 
 /**
- * Note: Passing a function has been @deprecated
+ * Warning: Passing a function has been @deprecated
  * and will be removed in the next major version.
  */
 export const get = <T, K>(
@@ -185,9 +185,6 @@ export const get = <T, K>(
   funcOrPath: ((t: T) => K) | string,
   defaultValue: K | null = null
 ): K => {
-  if (value === null || value === undefined) {
-    return defaultValue
-  }
   if (isFunction(funcOrPath)) {
     try {
       return (funcOrPath as Function)(value) ?? defaultValue
@@ -198,10 +195,12 @@ export const get = <T, K>(
   const segments = (funcOrPath as string).split(/[\.\[\]]/g)
   let current: any = value
   for (const key of segments) {
+    if (current === null) return defaultValue
+    if (current === undefined) return defaultValue
     if (key.trim() === '') continue
     current = current[key]
-    if (current === undefined) return defaultValue
   }
+  if (current === undefined) return defaultValue
   return current
 }
 

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -227,6 +227,8 @@ describe('object module', () => {
       assert.equal(_.get(jay, 'friends.1.age'), null)
       assert.equal(_.get(jay, 'friends.0.friends[0].name'), 'sara')
       assert.equal(_.get(jay, 'name'), 'jay')
+      assert.equal(_.get(jay, '[name]'), 'jay')
+      assert.equal(_.get(jay, 'friends[0][name]'), 'carl')
       assert.equal(_.get(jay, 'friends[0].friends[0].friends[0].age', 22), 22)
     })
   })

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -195,37 +195,39 @@ describe('object module', () => {
     type Person = {
       name: string
       age: number
-      friends: Person[]
+      friends?: Person[]
     }
-    const person: Person = {
+    const jay: Person = {
       name: 'jay',
       age: 17,
       friends: [{
-        name: 'chris',
-        age: 19,
-        friends: []
+        name: 'carl',
+        age: 17,
+        friends: [{
+          name: 'sara',
+          age: 17
+        }]
       }]
     }
-    test('handles null input', () => {
-      const result = _.get(null, x => x.name)
-      assert.equal(result, null)
+    test('handles null and undefined input', () => {
+      assert.equal(_.get(null, 'name'), null)
+      assert.equal(_.get(undefined, 'name'), null)
     })
-    test('returns specified value', () => {
-      const result = _.get(person, x => x.name)
-      assert.equal(result, 'jay')
+    test('returns specified value or default using function', () => {
+      assert.equal(_.get(jay, x => x.name), 'jay')
+      assert.equal(_.get(jay, x => x.friends?.[0].age), 17)
+      assert.equal(_.get(jay, x => {throw 'error'}, 17), 17)
+      assert.equal(_.get({ age: undefined }, x => x.age, 22), 22)
+      assert.equal(_.get(jay, x => x.friends?.[0].friends?.[0].friends?.[0].age, 22), 22)
     })
-    test('returns deep specified value', () => {
-      const result = _.get(person, x => x.friends[0].age)
-      assert.equal(result, 19)
-    })
-    test('returns default if value is undefined', () => {
-      const myPerson = { ...person, age: undefined }
-      const result = _.get(myPerson, x => x.age, 22)
-      assert.equal(result, 22)
-    })
-    test('returns given default if failure', () => {
-      const result = _.get(person, x => x.friends[0].friends[0].friends[0].age, 22)
-      assert.equal(result, 22)
+    test('returns specified value or default using path', () => {
+      assert.equal(_.get({ age: undefined }, 'age', 22), 22)
+      assert.equal(_.get(jay, 'friends[0].age'), 17)
+      assert.equal(_.get(jay, 'friends.0.age'), 17)
+      assert.equal(_.get(jay, 'friends.1.age'), null)
+      assert.equal(_.get(jay, 'friends.0.friends[0].name'), 'sara')
+      assert.equal(_.get(jay, 'name'), 'jay')
+      assert.equal(_.get(jay, 'friends[0].friends[0].friends[0].age', 22), 22)
     })
   })
 


### PR DESCRIPTION
Implementing dynamic get behavior by a string path. I extended the current `get` function we won't have to do a major version bump. On the next major version, we can update this to remove the function argument.

Resolves #22 