### PR TITLE
fix: getGroupId params typo in group

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -3,9 +3,9 @@
  * the group ids the given getGroupId function produced and the value is an array of
  * each item in that group.
  */
-export const group = <T>(array: readonly T[], getGropuId: (item: T) => string) => {
+export const group = <T>(array: readonly T[], getGroupId: (item: T) => string) => {
   return array.reduce((acc, item) => {
-    const groupId = getGropuId(item)
+    const groupId = getGroupId(item)
     const groupList = acc[groupId] ?? []
     return { ...acc, [groupId]: [...groupList, item] }
   }, {} as Record<string, T[]>)


### PR DESCRIPTION
renamed `getGropuId` to `getGroupId`, I assume this was not intentional.