### PR TITLE
Improve typings for lowerize and upperize return value

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -1,5 +1,13 @@
 import { isObject } from './typed'
 
+type LowercasedKeys<T extends Record<string, any>> = {
+  [P in keyof T & string as Lowercase<P>]: T[P]
+}
+
+type UppercasedKeys<T extends Record<string, any>> = {
+  [P in keyof T & string as Uppercase<P>]: T[P]
+}
+
 /**
  * Removes (shakes out) undefined entries from an
  * object. Optional second argument shakes out values
@@ -103,14 +111,14 @@ export const invert = <
 /**
  * Convert all keys in an object to lower case
  */
-export const lowerize = <T>(obj: Record<string, T>) =>
-  mapKeys(obj, k => k.toLowerCase())
+export const lowerize = <T extends Record<string, any>>(obj: T) =>
+  mapKeys(obj, k => k.toLowerCase()) as LowercasedKeys<T>
 
 /**
  * Convert all keys in an object to upper case
  */
-export const upperize = <T>(obj: Record<string, T>) =>
-  mapKeys(obj, k => k.toUpperCase())
+export const upperize = <T extends Record<string, any>>(obj: T) =>
+  mapKeys(obj, k => k.toUpperCase()) as UppercasedKeys<T>
 
 export const clone = <T extends object = object>(obj: T): T => {
   return Object.getOwnPropertyNames(obj).reduce(


### PR DESCRIPTION
## Motivation

`lowerize` and `upperize` are very useful utility methods for transforming an object's property names. With the current type definitions for these methods, we are losing some type information for the return value. As a consequence, we lose the auto-completion feature from IntelliSense after applying the transformation since TS only knows the type for the dictionary keys are `string`. This MR aims to narrow and make the types more precise and better model the actual data, so that we can still get auto-completion.

| Before (orig obj is type-safe)                                                                                                                                       | result obj loses type info                                                                                                                                          | After                                                                                                                                                                |                                                                                                                                                                      |   |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
| <img width="250" alt="Screenshot 2022-09-04 at 13 36 11" src="https://user-images.githubusercontent.com/1209351/188312005-ef38ec67-400c-4fdf-8143-0062b18e62cc.png"> | <img width="78" alt="Screenshot 2022-09-04 at 13 36 21" src="https://user-images.githubusercontent.com/1209351/188312010-dc2c2f79-9bc6-43cd-87b0-07f5ff14b3e1.png"> | <img width="184" alt="Screenshot 2022-09-04 at 13 36 39" src="https://user-images.githubusercontent.com/1209351/188312067-97ec2648-037d-4eab-a09b-2c6fb493ccc7.png"> | <img width="182" alt="Screenshot 2022-09-04 at 13 39 18" src="https://user-images.githubusercontent.com/1209351/188312068-3aaae907-d531-4ae3-bd1e-69db43827bd8.png">                                                                                