### PR TITLE
Improve the typing or tryit function

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -186,7 +186,7 @@ export const tryit = <TFunction extends (...args: any) => any>(
 ) => {
   return async (
     ...args: ArgumentsType<TFunction>
-  ): Promise<[Error, UnwrapPromisify<ReturnType<TFunction>>]> => {
+  ): Promise<[Error, null] | [null, UnwrapPromisify<ReturnType<TFunction>>]> => {
     try {
       return [null, await func(...(args as any))]
     } catch (err) {


### PR DESCRIPTION
Hi there,

For those of us using typescript strict mode, this small change allows the correct inference of the tuple returned by `_.try` (see screenshots below).
It shouldn't change anything for those who aren't in strict mode.

With the change :
![image](https://user-images.githubusercontent.com/20091960/189344270-08b6576a-ea55-4768-b5e6-48f36b167d0e.png)
