### PR TITLE
Improve the type of `group` when using union type key

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -3,12 +3,15 @@
  * the group ids the given getGroupId function produced and the value is an array of
  * each item in that group.
  */
-export const group = <T>(array: readonly T[], getGroupId: (item: T) => string) => {
+ export const group = <T, Key extends string | number | symbol>(
+  array: readonly T[],
+  getGroupId: (item: T) => Key
+) => {
   return array.reduce((acc, item) => {
     const groupId = getGroupId(item)
     const groupList = acc[groupId] ?? []
     return { ...acc, [groupId]: [...groupList, item] }
-  }, {} as Record<string, T[]>)
+  }, {} as Record<Key, T[]>)
 }
 
 /**


### PR DESCRIPTION
## Motivation

Sometimes, I want to use the `union type` for the key. However, the `group` function returns `string type` because the function always interpret a key as `string type`.

This PR uses the Generics for supporting `union types`.


## Example

```javascript
const fish = [{
  name: 'Marlin',
  source: 'ocean'
}, {
  name: 'Bass',
  source: 'lake'
}, {
  name: 'Trout',
  source: 'lake'
}] as const

const fishBySource = group(fish, f => f.source)
```

|before|after (this PR)|
|---|---|
|<img width="277" alt="before" src="https://user-images.githubusercontent.com/17381979/191211763-e9f22f98-c316-4b1b-b600-190adbdd2336.png">|<img width="350" alt="after" src="https://user-images.githubusercontent.com/17381979/191211799-a6b816e4-acc5-4369-935f-ba1c0e502404.png">|

