### PR TITLE
array: add shift function

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -403,9 +403,11 @@ export const diff = <T>(
  * If n < 0 items will shift n steps to the left
  */
  export function shift<T>(arr: Array<T>, n: number) {
-  if (n === 0 || arr.length === 0 || arr.length === n || n === -arr.length) return arr;
+  if (arr.length === 0) return arr;
 
   const shiftNumber = n % arr.length;
+
+  if(shiftNumber === 0) return arr;
 
   return [...arr.slice(-shiftNumber, arr.length), ...arr.slice(0, -shiftNumber)];
 }

--- a/src/array.ts
+++ b/src/array.ts
@@ -396,3 +396,14 @@ export const diff = <T>(
   )
   return root.filter(a => !bKeys[identity(a)])
 }
+
+/**
+ * Shift array items by n steps
+ * If n > 0 items will shift n steps to the right
+ * If n < 0 items will shift n steps to the left
+ */
+export function shift<T>(arr: ReadonlyArray<T>, n: number) {
+  if (n === 0) return arr;
+
+  return [...arr.slice(-n, arr.length), ...arr.slice(0, -n)];
+}

--- a/src/array.ts
+++ b/src/array.ts
@@ -402,8 +402,10 @@ export const diff = <T>(
  * If n > 0 items will shift n steps to the right
  * If n < 0 items will shift n steps to the left
  */
-export function shift<T>(arr: ReadonlyArray<T>, n: number) {
-  if (n === 0) return arr;
+ export function shift<T>(arr: Array<T>, n: number) {
+  if (n === 0 || arr.length === 0 || arr.length === n || n === -arr.length) return arr;
 
-  return [...arr.slice(-n, arr.length), ...arr.slice(0, -n)];
+  const shiftNumber = n % arr.length;
+
+  return [...arr.slice(-shiftNumber, arr.length), ...arr.slice(0, -shiftNumber)];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ export {
   sift,
   sort,
   sum,
-  unique
+  unique,
+  shift
 } from './array'
 export {
   defer,

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -611,5 +611,11 @@ describe('array module', () => {
       const result = _.shift(arr, 9);      
       assert.deepEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     });
+    test('should return empty array',()=>{
+      const results = _.shift([],0)
+    })    
+    test('should return empty array',()=>{
+      const results = _.shift([],10)
+    })
   });
 })

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -586,32 +586,30 @@ describe('array module', () => {
   })
 
   describe('shift function', () => {
-    it('should shift array right 3 positions', () => {
-      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-      const shiftNumber = 3;
-      const expected = [7, 8, 9, 1, 2, 3, 4, 5, 6];
-
-      const resArr = _.shift(arr, shiftNumber);
-      expect(resArr).toEqual(expected);
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];    
+    test('should shift array right 3 positions', () => {
+      const result = _.shift(arr, 3);
+      assert.deepEqual(result, [7, 8, 9, 1, 2, 3, 4, 5, 6])
     });
-
-    it('should shift array left 3 positions', () => {
-      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-      const shiftNumber = -3;
-      const expected = [4, 5, 6, 7, 8, 9, 1, 2, 3];
-
-      const resArr = _.shift(arr, shiftNumber);
-      expect(resArr).toEqual(expected);
+    test('should shift array left 3 positions', () => {
+      const result = _.shift(arr, -3);      
+      assert.deepEqual(result, [4, 5, 6, 7, 8, 9, 1, 2, 3])
+    });    
+    test('should shift array right 6 positions', () => {
+      const result = _.shift(arr, 15);      
+      assert.deepEqual(result, [4, 5, 6, 7, 8, 9, 1, 2, 3])
+    });    
+    test('should shift array left 6 positions', () => {
+      const result = _.shift(arr, -15);      
+      assert.deepEqual(result, [ 7, 8, 9, 1, 2, 3, 4, 5, 6 ])
     });
-
-    it('should keep array as is', () => {
-      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-      const shiftNumber = 0;
-      const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
-      const resArr = _.shift(arr, shiftNumber);
-      expect(resArr).toEqual(expected);
+    test('should keep array as is', () => {
+      const result = _.shift(arr, 0);      
+      assert.deepEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    });    
+    test('should keep array as is', () => {
+      const result = _.shift(arr, 9);      
+      assert.deepEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     });
   });
-
 })

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -612,10 +612,12 @@ describe('array module', () => {
       assert.deepEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     });
     test('should return empty array',()=>{
-      const results = _.shift([],0)
+      const results = _.shift([], 0)
+      assert.deepEqual(results, []);
     })    
     test('should return empty array',()=>{
-      const results = _.shift([],10)
+      const results = _.shift([], 10)
+      assert.deepEqual(results, []);
     })
   });
 })

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -585,4 +585,33 @@ describe('array module', () => {
     })
   })
 
+  describe('shift function', () => {
+    it('should shift array right 3 positions', () => {
+      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+      const shiftNumber = 3;
+      const expected = [7, 8, 9, 1, 2, 3, 4, 5, 6];
+
+      const resArr = _.shift(arr, shiftNumber);
+      expect(resArr).toEqual(expected);
+    });
+
+    it('should shift array left 3 positions', () => {
+      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+      const shiftNumber = -3;
+      const expected = [4, 5, 6, 7, 8, 9, 1, 2, 3];
+
+      const resArr = _.shift(arr, shiftNumber);
+      expect(resArr).toEqual(expected);
+    });
+
+    it('should keep array as is', () => {
+      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+      const shiftNumber = 0;
+      const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      const resArr = _.shift(arr, shiftNumber);
+      expect(resArr).toEqual(expected);
+    });
+  });
+
 })


### PR DESCRIPTION
Request to add **shift** function:

Example: 
I have array: [1, 2, 3, 4, 5, 6, 7, 8, 9];
I want to shift array n positions right/left

Usage:

```
const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];

const shiftedArr = shift(arr, 3); // [7, 8, 9, 1, 2, 3, 4, 5, 6]
const shiftedLeftArr = shift(arr,-3); // [4, 5, 6, 7, 8, 9, 1, 2, 3]
```

