### PR TITLE
change sift return type from T to NonNullable<T>

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -3,7 +3,10 @@
  * the group ids the given getGroupId function produced and the value is an array of
  * each item in that group.
  */
-export const group = <T>(array: readonly T[], getGroupId: (item: T) => string) => {
+export const group = <T>(
+  array: readonly T[],
+  getGroupId: (item: T) => string
+) => {
   return array.reduce((acc, item) => {
     const groupId = getGroupId(item)
     const groupList = acc[groupId] ?? []
@@ -18,7 +21,10 @@ export const group = <T>(array: readonly T[], getGroupId: (item: T) => string) =
  *
  * Ex. const greatest = () => boil(numbers, (a, b) => a > b)
  */
-export const boil = <T>(array: readonly T[], compareFunc: (a: T, b: T) => T) => {
+export const boil = <T>(
+  array: readonly T[],
+  compareFunc: (a: T, b: T) => T
+) => {
   if (!array || (array.length ?? 0) === 0) return null
   return array.reduce(compareFunc)
 }
@@ -307,7 +313,11 @@ export const fork = <T>(
  * and replace items matched by the matcher func in the
  * first place.
  */
-export const merge = <T>(root: readonly T[], others: readonly T[], matcher: (item: T) => any) => {
+export const merge = <T>(
+  root: readonly T[],
+  others: readonly T[],
+  matcher: (item: T) => any
+) => {
   if (!others && !root) return []
   if (!others) return root
   if (!root) return []
@@ -349,7 +359,7 @@ export const replaceOrAppend = <T>(
  * Given a list returns a new list with
  * only truthy values
  */
-export const sift = <T>(list: readonly T[]) => {
+export const sift = <T>(list: readonly T[]): NonNullable<T>[] => {
   return list?.filter(x => !!x) ?? []
 }
 


### PR DESCRIPTION
## Description
Better typing on the `sift` function, resulting array is always not null elements by design. Also includes format changes from some unformatted changes that snuck in long ago.

## Checklist
[x] Changes are covered by tests if bahevior has been changed or added
[x] Tests have 100% coverage
[x] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
Resolves #68 
