### PR TITLE
fix: diff function when root is []

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/array.ts
+++ b/src/array.ts
@@ -395,7 +395,7 @@ export const diff = <T>(
     t as unknown as string | number | symbol
 ): T[] => {
   if (!root?.length && !other?.length) return []
-  if (!root?.length) return [...other]
+  if (root?.length === undefined) return [...other]
   if (!other?.length) return [...root]
   const bKeys = other.reduce(
     (acc, item) => ({

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -518,6 +518,14 @@ describe('array module', () => {
       const result = _.diff(null, null)
       assert.deepEqual(result, [])
     })
+    test('handles empty array root', () => {
+      const result = _.diff([], ['a'])
+      assert.deepEqual(result, [])
+    })
+    test('handles empty array other', () => {
+      const result = _.diff(['a'], [])
+      assert.deepEqual(result, ['a'])
+    })
     test('returns all items from root that dont exist in other', () => {
       const result = _.diff(
         ['a', 'b', 'c'],


### PR DESCRIPTION
## Description
Fix the behavior of the diff function when the root element is an empty array.
Now, if root is an empty array [] it will be returned as is, instead if root is null, other will be returned

This addresses the issue where `diff([], ['a'])` returned `['a']`. Now `diff([], ['a'])` returns `[]`.
I also added two test cases to address `diff([], ['a'])` and `diff(['a'], [])`

## Checklist
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
Resolves #107 
