### PR TITLE
fix: address pick issue when key not in object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/object.ts
+++ b/src/object.ts
@@ -156,7 +156,9 @@ export const pick = <T, TKeys extends keyof T>(
 ): Pick<T, TKeys> => {
   if (!obj) return {} as Pick<T, TKeys>
   return keys.reduce((acc, key) => {
-    return { ...acc, [key]: obj[key] }
+    if(typeof(obj[key]) !== 'undefined')
+      acc[key] = obj[key]
+    return acc;
   }, {} as Pick<T, TKeys>)
 }
 

--- a/src/object.ts
+++ b/src/object.ts
@@ -150,13 +150,13 @@ export const listify = <TValue, TKey extends string | number | symbol, KResult>(
  * Pick a list of properties from an object
  * into a new object
  */
-export const pick = <T, TKeys extends keyof T>(
+export const pick = <T extends Record<string, unknown>, TKeys extends keyof T>(
   obj: T,
   keys: TKeys[]
 ): Pick<T, TKeys> => {
   if (!obj) return {} as Pick<T, TKeys>
   return keys.reduce((acc, key) => {
-    if(typeof(obj[key]) !== 'undefined')
+    if(obj.hasOwnProperty(key))
       acc[key] = obj[key]
     return acc;
   }, {} as Pick<T, TKeys>)

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -156,6 +156,18 @@ describe('object module', () => {
       const result = _.pick({ a: 2 }, [])
       assert.deepEqual(result, {})
     })
+    test('handle key not in object', () => {
+      const result = _.pick({ a: 2, b: 3 } as any, ['c'])
+      assert.deepEqual(result, {} as any)
+    })
+    test('handle one key not in object', () => {
+      const result = _.pick({ a: 2, b: 3 } as any, ['a', 'c'])
+      assert.deepEqual(result, { a: 2 } as any)
+    })
+    test('does not ignore undefined values', () => {
+      const result = _.pick({ a: 2, b: undefined }, ['b'])
+      assert.deepEqual(result, { b: undefined })
+    })
     test('returns picked properties only', () => {
       const result = _.pick({ a: 2, b: 4 }, ['a'])
       assert.deepEqual(result, {


### PR DESCRIPTION
## Description
With this PR I am trying to address the issue #67, where the `pick` function, when provided with a key not present in the source object, will return `{[key]: undefined}`. With these changes, if the key is not present in the object it will not appear in the final object

## Checklist
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
Resolves #67
