### PR TITLE
Add index to async map callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/async.ts
+++ b/src/async.ts
@@ -29,11 +29,13 @@ export const reduce = async <T, K>(
  */
 export const map = async <T, K>(
   array: readonly T[],
-  asyncMapFunc: (item: T) => Promise<K>
+  asyncMapFunc: (item: T, index: number) => Promise<K>
 ): Promise<K[]> => {
+  if (!array) return []
   let result = []
+  let index = 0
   for (const value of array) {
-    const newValue = await asyncMapFunc(value)
+    const newValue = await asyncMapFunc(value, index++)
     result.push(newValue)
   }
   return result
@@ -186,7 +188,9 @@ export const tryit = <TFunction extends (...args: any) => any>(
 ) => {
   return async (
     ...args: ArgumentsType<TFunction>
-  ): Promise<[Error, null] | [null, UnwrapPromisify<ReturnType<TFunction>>]> => {
+  ): Promise<
+    [Error, null] | [null, UnwrapPromisify<ReturnType<TFunction>>]
+  > => {
     try {
       return [null, await func(...(args as any))]
     } catch (err) {

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -30,6 +30,18 @@ describe("async module", () => {
       const result = await _.map<number, number>(numbers, asyncSquare);
       assert.deepEqual(result, [1, 4, 9, 16]);
     });
+
+    test("handles null input", async () => {
+      const result = await _.map(null, async () => '');
+      assert.deepEqual(result, []);
+    });
+    
+    test("passes correct indexes", async () => {
+      const array = ['a', 'b', 'c', 'd'];
+      const mapper = async (l: string, index: number) => `${l}${index}`;
+      const result = await _.map(array, mapper);
+      assert.deepEqual(result, ['a0', 'b1', 'c2', 'd3']);
+    });
   });
 
   describe("reduce/asyncReduceV2 function", () => {
@@ -63,17 +75,6 @@ describe("async module", () => {
         return;
       }
       assert.fail("Expected error to be thrown");
-    });
-  });
-
-  describe("map/asyncMapV2 function", () => {
-    test("calls asyncMap", async () => {
-      const numbers = [1, 2, 3, 4];
-      const asyncSquare = async (a: number): Promise<number> => {
-        return new Promise((res) => res(a * a));
-      };
-      const result = await _.map<number, number>(numbers, asyncSquare);
-      assert.deepEqual(result, [1, 4, 9, 16]);
     });
   });
 


### PR DESCRIPTION
## Description
Added a second argument to the callback used with `map` that is the current index (just like the builtin sync map function).

## Checklist
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
Resolves #55
