### PR TITLE
test: use fake timer for test

### DIFF
--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai'
 import * as _ from '..'
 
 describe('async module', () => {
-  beforeEach(() => jest.useFakeTimers({ advanceTimers: true }));
+  beforeEach(() => jest.useFakeTimers({ advanceTimers: true }))
 
   describe('asyncReduce function', () => {
     test('returns result of reducer', async () => {
@@ -84,28 +84,7 @@ describe('async module', () => {
       await _.defer(async defer => {
         defer(() => {
           val = 1
-        });
-      })
-      assert.equal(val, 1);
-    });
-    test("returns the resulting value of the given function", async () => {
-      let val = 0;
-      const result = await _.defer(async (defer) => {
-        defer(() => {val = 1});
-        return "x";
-      });
-      assert.equal(val, 1);
-      assert.equal(result, "x");
-    });
-    test("calls all registered defer functions", async () => {
-      let one = 0;
-      let two = 0;
-      let three = 0;
-      const result = await _.defer(async (defer) => {
-        defer(async () => {one = 1});
-        defer(async () => {two = 2});
-        defer(async () => {three = 3});
-        return "x";
+        })
       })
       assert.equal(val, 1)
     })
@@ -254,10 +233,10 @@ describe('async module', () => {
 
   describe('_.sleep function', () => {
     test('suspends a thread for a specified number of milliseconds', async () => {
-      const ONE_SECOND = 1000;
-      const before = Date.now();
+      const ONE_SECOND = 1000
+      const before = Date.now()
       await _.sleep(ONE_SECOND)
-      const after = Date.now();
+      const after = Date.now()
       assert.isAtLeast(after, before + ONE_SECOND)
     })
   })
@@ -344,7 +323,7 @@ describe('async module', () => {
     })
     test('quits after max retries', async () => {
       try {
-        await _.retry({}, async () => { 
+        await _.retry({}, async () => {
           throw 'quitagain'
         })
       } catch (err) {
@@ -355,7 +334,7 @@ describe('async module', () => {
     })
     test('quits after max retries without delay', async () => {
       try {
-        const func = async () => { 
+        const func = async () => {
           throw 'quitagain'
         }
         await _.retry({ times: 3 }, func)
@@ -367,7 +346,7 @@ describe('async module', () => {
     })
     test('quits after max retries with delay', async () => {
       try {
-        const func = async () => { 
+        const func = async () => {
           throw 'quitagain'
         }
         await _.retry({ delay: 100 }, func)

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -84,7 +84,28 @@ describe('async module', () => {
       await _.defer(async defer => {
         defer(() => {
           val = 1
-        })
+        });
+      })
+      assert.equal(val, 1);
+    });
+    test("returns the resulting value of the given function", async () => {
+      let val = 0;
+      const result = await _.defer(async (defer) => {
+        defer(() => {val = 1});
+        return "x";
+      });
+      assert.equal(val, 1);
+      assert.equal(result, "x");
+    });
+    test("calls all registered defer functions", async () => {
+      let one = 0;
+      let two = 0;
+      let three = 0;
+      const result = await _.defer(async (defer) => {
+        defer(async () => {one = 1});
+        defer(async () => {two = 2});
+        defer(async () => {three = 3});
+        return "x";
       })
       assert.equal(val, 1)
     })
@@ -323,7 +344,7 @@ describe('async module', () => {
     })
     test('quits after max retries', async () => {
       try {
-        await _.retry({}, async () => {
+        await _.retry({}, async () => { 
           throw 'quitagain'
         })
       } catch (err) {
@@ -334,7 +355,7 @@ describe('async module', () => {
     })
     test('quits after max retries without delay', async () => {
       try {
-        const func = async () => {
+        const func = async () => { 
           throw 'quitagain'
         }
         await _.retry({ times: 3 }, func)
@@ -346,7 +367,7 @@ describe('async module', () => {
     })
     test('quits after max retries with delay', async () => {
       try {
-        const func = async () => {
+        const func = async () => { 
           throw 'quitagain'
         }
         await _.retry({ delay: 100 }, func)

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -1,9 +1,9 @@
 import { assert } from 'chai'
 import * as _ from '..'
 
-jest.useRealTimers()
-
 describe('async module', () => {
+  beforeEach(() => jest.useFakeTimers({ advanceTimers: true }));
+
   describe('asyncReduce function', () => {
     test('returns result of reducer', async () => {
       const numbers = [
@@ -232,15 +232,10 @@ describe('async module', () => {
   })
 
   describe('_.sleep function', () => {
-    beforeAll(() => jest.useFakeTimers());
-    afterAll(() => jest.useRealTimers());
-
-    test('waits no more than 1000ms', async () => {
+    test('suspends a thread for a specified number of milliseconds', async () => {
       const ONE_SECOND = 1000;
       const before = Date.now();
-      const res = _.sleep(ONE_SECOND)
-      jest.runAllTimers()
-      await res;
+      await _.sleep(ONE_SECOND)
       const after = Date.now();
       assert.isAtLeast(after, before + ONE_SECOND)
     })
@@ -279,7 +274,7 @@ describe('async module', () => {
         await _.sleep(300)
         numInProgress--
       })
-      assert.deepEqual(tracking, [1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3])
+      assert.deepEqual(Math.max(...tracking), 3)
     })
   })
 

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -232,11 +232,17 @@ describe('async module', () => {
   })
 
   describe('_.sleep function', () => {
-    test('returns error when error is thrown', async () => {
-      const before = Date.now()
-      await _.sleep(1000)
-      const after = Date.now()
-      assert.isAtLeast(after, before + 1000)
+    beforeAll(() => jest.useFakeTimers());
+    afterAll(() => jest.useRealTimers());
+
+    test('waits no more than 1000ms', async () => {
+      const ONE_SECOND = 1000;
+      const before = Date.now();
+      const res = _.sleep(ONE_SECOND)
+      jest.runAllTimers()
+      await res;
+      const after = Date.now();
+      assert.isAtLeast(after, before + ONE_SECOND)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,13 +195,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.7.2":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
-  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
-
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -494,7 +487,7 @@
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.1.0"
+    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.9"
     jest-haste-map "^28.1.3"
     jest-regex-util "^28.0.2"
@@ -1261,7 +1254,7 @@ expect@^28.0.0, expect@^28.1.3:
     jest-message-util "^28.1.3"
     jest-util "^28.1.3"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1665,7 +1658,6 @@ jest-mock@^28.1.3:
   dependencies:
     "@jest/types" "^28.1.3"
     "@types/node" "*"
-    jest-util "^29.2.1"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -1742,6 +1734,7 @@ jest-runtime@^28.1.3:
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
+    execa "^5.0.0"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
     jest-haste-map "^28.1.3"
@@ -1761,7 +1754,6 @@ jest-snapshot@^28.1.3:
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
-    "@babel/plugin-syntax-jsx" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
@@ -1828,7 +1820,6 @@ jest-worker@^28.1.3:
   integrity sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==
   dependencies:
     "@types/node" "*"
-    jest-util "^29.2.1"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -2177,6 +2168,13 @@ resolve@^1.17.0, resolve@^1.20.0, resolve@^1.3.2:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rollup-plugin-dts@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-4.2.3.tgz#04c3615df1ffab4228aa9d540697eaca61e01f47"
@@ -2324,7 +2322,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2337,6 +2335,14 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+supports-hyperlinks@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
+  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -487,7 +494,7 @@
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
     graceful-fs "^4.2.9"
     jest-haste-map "^28.1.3"
     jest-regex-util "^28.0.2"
@@ -1254,7 +1261,7 @@ expect@^28.0.0, expect@^28.1.3:
     jest-message-util "^28.1.3"
     jest-util "^28.1.3"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1658,6 +1665,7 @@ jest-mock@^28.1.3:
   dependencies:
     "@jest/types" "^28.1.3"
     "@types/node" "*"
+    jest-util "^29.2.1"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -1734,7 +1742,6 @@ jest-runtime@^28.1.3:
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
-    execa "^5.0.0"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
     jest-haste-map "^28.1.3"
@@ -1754,6 +1761,7 @@ jest-snapshot@^28.1.3:
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
@@ -1820,6 +1828,7 @@ jest-worker@^28.1.3:
   integrity sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==
   dependencies:
     "@types/node" "*"
+    jest-util "^29.2.1"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -2168,13 +2177,6 @@ resolve@^1.17.0, resolve@^1.20.0, resolve@^1.3.2:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 rollup-plugin-dts@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-4.2.3.tgz#04c3615df1ffab4228aa9d540697eaca61e01f47"
@@ -2322,7 +2324,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2335,14 +2337,6 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
-
-supports-hyperlinks@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
-  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
-  dependencies:
-    has-flag "^4.0.0"
-    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description
We can use fake timers from jest to control the passage of time in tests.

## Checklist
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
Resolves #102 

## Investigation
Jest library has issues when the system under test is mixing micro-tasks and macro-tasks.
https://github.com/facebook/jest/issues/13435, https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function

Because the current implementation of the sleep function uses promise and timeout, we can't just call the useFakeTimers function in tests.

So, I suggest to use solution from https://github.com/facebook/jest/issues/11876#issuecomment-1090173771.