### PR TITLE
Make license in package.json BSD-3-Clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "rayepps",
   "private": false,
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "test": "jest --coverage",
     "check": "yarn lint && yarn test && yarn build",


### PR DESCRIPTION
## Description
Make the license field in the package.json match the LICENSE in the repo.

## Checklist
n/a

## Resolves
Resolves #121 
