### PR TITLE
Change publish on release workflow trigger: created -> published

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,7 +1,7 @@
 name: Publish Package to npm
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
The current publish workflow (`publish-on-release.yml`) isn't getting trigger when I expect it to -- when a release is created. Changing the trigger to `published` to see if it will work as desired.

## Checklist
n/a

## Resolves
n/a
