### PR TITLE
bump tag-exists-action version

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Get Current Version
         id: get-version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-      - uses: mukunku/tag-exists-action@v1.0.0
+      - uses: mukunku/tag-exists-action@v1.1.0
         id: check-tag
         with:
-          tag: v${{ steps.get-version.outputs.version}}
+          tag: v${{ steps.get-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release:


### PR DESCRIPTION
## Description
This change bumps the tag-exists-action version to v1.1.0 and should get rid of [these warnings](https://github.com/rayepps/radash/actions/runs/3326917995):
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/4502154/198735215-47822e4a-74d1-4ddc-9151-2048a146bdbc.png">

