### PR TITLE
allow null default in toFloat and toInt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/number.ts
+++ b/src/number.ts
@@ -2,20 +2,22 @@ export const toFloat = <T extends number | null = number>(
   value: any,
   defaultValue?: T
 ): number | T => {
+  const def = defaultValue === undefined ? 0.0 : defaultValue
   if (value === null || value === undefined) {
-    return defaultValue ?? 0.0
+    return def
   }
   const result = parseFloat(value)
-  return isNaN(result) ? defaultValue ?? 0.0 : result
+  return isNaN(result) ? def : result
 }
 
 export const toInt = <T extends number | null>(
   value: any,
   defaultValue?: T
 ): number | T => {
+  const def = defaultValue === undefined ? 0 : defaultValue
   if (value === null || value === undefined) {
-    return defaultValue ?? 0
+    return def
   }
   const result = parseInt(value)
-  return isNaN(result) ? defaultValue ?? 0 : result
+  return isNaN(result) ? def : result
 }

--- a/src/number.ts
+++ b/src/number.ts
@@ -3,10 +3,10 @@ export const toFloat = <T extends number | null = number>(
   defaultValue?: T
 ): number | T => {
   if (value === null || value === undefined) {
-    return defaultValue ?? (0.0 as T)
+    return defaultValue ?? 0.0
   }
   const result = parseFloat(value)
-  return isNaN(result) ? defaultValue ?? (0.0 as T) : (result as T)
+  return isNaN(result) ? defaultValue ?? 0.0 : result
 }
 
 export const toInt = <T extends number | null>(
@@ -14,8 +14,8 @@ export const toInt = <T extends number | null>(
   defaultValue?: T
 ): number | T => {
   if (value === null || value === undefined) {
-    return defaultValue ?? (0 as T)
+    return defaultValue ?? 0
   }
   const result = parseInt(value)
-  return isNaN(result) ? defaultValue ?? (0 as T) : (result as T)
+  return isNaN(result) ? defaultValue ?? 0 : result
 }

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,4 +1,7 @@
-export const toFloat = (value: any, defaultValue: number = 0.0) => {
+export const toFloat = (
+  value: any,
+  defaultValue: number | null = 0.0
+): number | null => {
   if (value === null || value === undefined) {
     return defaultValue
   }
@@ -6,7 +9,10 @@ export const toFloat = (value: any, defaultValue: number = 0.0) => {
   return isNaN(result) ? defaultValue : result
 }
 
-export const toInt = (value: any, defaultValue: number = 0) => {
+export const toInt = (
+  value: any,
+  defaultValue: number | null = 0
+): number | null => {
   if (value === null || value === undefined) {
     return defaultValue
   }

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,21 +1,21 @@
-export const toFloat = (
+export const toFloat = <T extends number | null = number>(
   value: any,
-  defaultValue: number | null = 0.0
-): number | null => {
+  defaultValue?: T
+): number | T => {
   if (value === null || value === undefined) {
-    return defaultValue
+    return defaultValue ?? (0.0 as T)
   }
   const result = parseFloat(value)
-  return isNaN(result) ? defaultValue : result
+  return isNaN(result) ? defaultValue ?? (0.0 as T) : (result as T)
 }
 
-export const toInt = (
+export const toInt = <T extends number | null>(
   value: any,
-  defaultValue: number | null = 0
-): number | null => {
+  defaultValue?: T
+): number | T => {
   if (value === null || value === undefined) {
-    return defaultValue
+    return defaultValue ?? (0 as T)
   }
   const result = parseInt(value)
-  return isNaN(result) ? defaultValue : result
+  return isNaN(result) ? defaultValue ?? (0 as T) : (result as T)
 }

--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -11,6 +11,10 @@ describe('number module', () => {
       const result = _.toFloat(undefined)
       assert.strictEqual(result, 0.0)
     })
+    test('uses null default', () => {
+      const result = _.toFloat('x', null)
+      assert.strictEqual(result, null)
+    })
     test('handles bad input', () => {
       const result = _.toFloat({})
       assert.strictEqual(result, 0.0)
@@ -24,6 +28,10 @@ describe('number module', () => {
     test('handles null', () => {
       const result = _.toInt(null)
       assert.strictEqual(result, 0)
+    })
+    test('uses null default', () => {
+      const result = _.toInt('x', null)
+      assert.strictEqual(result, null)
     })
     test('handles undefined', () => {
       const result = _.toInt(undefined)


### PR DESCRIPTION
## Description
In some cases you may want to get null back as the default value if converting to a number fails. Ex. `toInt('x', null)` but the current types don't allow for this. This change allows it. *only changing the types*

## Checklist
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] The version in `package.json` has been bumped according to the changes made and standard semantic versioning rules

## Resolves
n/a
