### PR TITLE
Fix CI error, use yarn to install semver

### DIFF
--- a/.github/workflows/semver-on-release-labeled-pr.yml
+++ b/.github/workflows/semver-on-release-labeled-pr.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install semver
+      - run: yarn add semver
       - uses: actions/github-script@v6
         env:
           PR_VERSION: ${{steps.pr-version.outputs.version}}


### PR DESCRIPTION
## Description
NPM is a bit more strict than yarn when checking peer dependencies. We're currently (knowingly) using mistmatching rollup plugin packages because an update hasn't been done by that package yet so when we run `npm instal semver` NPM is throwing an error. Yarn is graceful about it and only warns so switching to it.

## Checklist
n/a

## Resolves
n/a
