### PR TITLE
add registry-url to publish ci job

### DIFF
--- a/.github/workflows/release-and-publish-on-merge.yml
+++ b/.github/workflows/release-and-publish-on-merge.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn
       - run: yarn build
       - run: npm publish


### PR DESCRIPTION
## Description
Per the [github action docs](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) we need to specify the `registry-url` on the `node-setup` action or the authentication to npm won't work. Currently, its not working: [see failing action](https://github.com/rayepps/radash/actions/runs/3381882800/jobs/5616234257).

## Checklist
n/a

## Resolves
n/a
