### PR TITLE
build: bump rollup-plugin-esbuild to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier-plugin-organize-imports": "^3.0.3",
     "rollup": "^3.2.5",
     "rollup-plugin-dts": "^5.0.0",
-    "rollup-plugin-esbuild": "^4.10.2",
+    "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-node-externals": "^5.0.2",
     "ts-jest": "^28.0.8",
     "tslint": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@ rollup-plugin-dts@^5.0.0:
   optionalDependencies:
     "@babel/code-frame" "^7.18.6"
 
-rollup-plugin-esbuild@^4.10.2:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.10.2.tgz#094a2178764af182ae08764e4dedff6b14793091"
-  integrity sha512-OPrBgdN1ZC2zQvq/rm5Zvzpb0Rez7zbbVJ+1b5Az//kLlfhwR1mqOP3wAhkg9sn5nF7p+97p55TORE0RNXzNcw==
+rollup-plugin-esbuild@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-esbuild/-/rollup-plugin-esbuild-5.0.0.tgz#6cce358f4abe164d65a0028e900b8501a15f72ef"
+  integrity sha512-1cRIOHAPh8WQgdQQyyvFdeOdxuiyk+zB5zJ5+YOwrZP4cJ0MT3Fs48pQxrZeyZHcn+klFherytILVfE4aYrneg==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     debug "^4.3.4"


### PR DESCRIPTION
## Description
rollup-plugin-esbuild `4.10.2` was meant to be the major versrion `5.0.0`, since it conitained breaking changes (drop support for noode below 14)
This PR bumps rollup-plugin-esbuild to major version 5.0.0 to keep support rollup 3

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [x] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory

## Resolves

Resolves #146 
