### PR TITLE
Add CI/CD step to check cdn files are up to date

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -36,11 +36,11 @@ jobs:
       - run: npm install -g checksum
       - name: Calc current cdn checksums
         id: current-checksums
-        run: echo "checksums=$(checksum cdn/* | base64)" >> $GITHUB_OUTPUT
+        run: echo "checksums=$(checksum cdn/* | base64 | tr '\n' ' ')" >> $GITHUB_OUTPUT
       - run: yarn build
       - name: Calc built cdn checksums
         id: built-checksums
-        run: echo "checksums=$(checksum cdn/* | base64)" >> $GITHUB_OUTPUT
+        run: echo "checksums=$(checksum cdn/* | base64 | tr '\n' ' ')" >> $GITHUB_OUTPUT
       - uses: actions/github-script@v6
         env:
           CURRENT_CHECKSUMS: ${{steps.current-checksums.outputs.checksums}}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -25,3 +25,34 @@ jobs:
           node-version: '16.x'
       - run: yarn
       - run: yarn format:check
+  verify-cdn-build-matches-src:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - run: yarn
+      - run: npm install -g checksum
+      - name: Calc current cdn checksums
+        id: current-checksums
+        run: echo "checksums=$(checksum cdn/*)" >> $GITHUB_OUTPUT
+      - run: yarn build
+      - name: Calc built cdn checksums
+        id: built-checksums
+        run: echo "checksums=$(checksum cdn/*)" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v6
+        env:
+          CURRENT_CHECKSUMS: ${{steps.current-checksums.outputs.checksums}}
+          BUILT_CHECKSUMS: ${{steps.built-checksums.outputs.checksums}}
+        with:
+          script: |
+            const { 
+              CURRENT_CHECKSUMS: current, 
+              BUILT_CHECKSUMS: built 
+            } = process.env
+            if (current.trim() !== built.trim()) {
+              core.setFailed(`The files in the cdn directory don't match the expected output given the source. Maybe you didn't run yarn build before pushing?`)
+            } else {
+              core.debug(`Success, the cdn build files reflect the current source code.`)
+            }

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -36,11 +36,11 @@ jobs:
       - run: npm install -g checksum
       - name: Calc current cdn checksums
         id: current-checksums
-        run: echo "checksums=$(checksum cdn/*)" >> $GITHUB_OUTPUT
+        run: echo "checksums=$(checksum cdn/* | base64)" >> $GITHUB_OUTPUT
       - run: yarn build
       - name: Calc built cdn checksums
         id: built-checksums
-        run: echo "checksums=$(checksum cdn/*)" >> $GITHUB_OUTPUT
+        run: echo "checksums=$(checksum cdn/* | base64)" >> $GITHUB_OUTPUT
       - uses: actions/github-script@v6
         env:
           CURRENT_CHECKSUMS: ${{steps.current-checksums.outputs.checksums}}

--- a/cdn/radash.js
+++ b/cdn/radash.js
@@ -1,6 +1,5 @@
 var radash = (function (exports) {
-  'use strict';
-
+  
   const group = (array, getGroupId) => {
     return array.reduce((acc, item) => {
       const groupId = getGroupId(item);

--- a/cdn/radash.js
+++ b/cdn/radash.js
@@ -1,5 +1,6 @@
 var radash = (function (exports) {
-  
+  'use strict';
+
   const group = (array, getGroupId) => {
     return array.reduce((acc, item) => {
       const groupId = getGroupId(item);


### PR DESCRIPTION
## Description

Currently we have a CI check that asserts the `.version` in the `/cdn` folder matches the version in the package.json. That isn't really bullet proof though because a contributor could run the build, the .version would then match, and then they could make more changes so the cdn files are out of date again.

This PR generates a checksum on the `/cdn/*` folder, then runs the build, then generates the checksum on the `/cdn/*` folder again, then asserts the two checksums match. This tells us the build files match the source.

## Checklist

n/a

## Resolves

n/a
