### PR TITLE
Fix publish error on master branch

### DIFF
--- a/.github/workflows/release-and-publish-on-merge.yml
+++ b/.github/workflows/release-and-publish-on-merge.yml
@@ -41,6 +41,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
   publish:
     runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.exists == 'false'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Description

We should only try to publish if there is no release. This was overlooked in the first version of the github workflows. Added the same check that release has so it only runs when a release doesn't exist. It was running on every merge which was causing failed actions.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory

## Resolves

n/a
