### PR TITLE
turn down dependaboy frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
## Description

Dependabot has become incredibly annoying... PRs every day for patch and minor version bumps. Not at all needed mainly because all of our dependencies are dev.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory

## Resolves

If the PR resolves an open issue tag it here. For example, `Resolves #34`
