### PR TITLE
fix: move types to be first entry in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.cjs",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/cjs/index.cjs"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
> "types" - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.

https://nodejs.org/api/packages.html#community-conditions-definitions

https://publint.dev/radash@10.3.2