### PR TITLE
fix pick types to allow interfaces

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -166,7 +166,7 @@ export const listify = <TValue, TKey extends string | number | symbol, KResult>(
  * Pick a list of properties from an object
  * into a new object
  */
-export const pick = <T extends Record<string, unknown>, TKeys extends keyof T>(
+export const pick = <T extends object, TKeys extends keyof T>(
   obj: T,
   keys: TKeys[]
 ): Pick<T, TKeys> => {

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -213,11 +213,11 @@ describe('object module', () => {
       assert.deepEqual(result, {})
     })
     test('handle key not in object', () => {
-      const result = _.pick({ a: 2, b: 3 } as any, ['c'])
+      const result = _.pick({ a: 2, b: 3 }, ['c'] as any)
       assert.deepEqual(result, {} as any)
     })
     test('handle one key not in object', () => {
-      const result = _.pick({ a: 2, b: 3 } as any, ['a', 'c'])
+      const result = _.pick({ a: 2, b: 3 }, ['a', 'c'] as any)
       assert.deepEqual(result, { a: 2 } as any)
     })
     test('does not ignore undefined values', () => {
@@ -228,6 +228,22 @@ describe('object module', () => {
       const result = _.pick({ a: 2, b: 4 }, ['a'])
       assert.deepEqual(result, {
         a: 2
+      })
+    })
+    test('type: accepts an interface', () => {
+      interface SomeDeclaredType {
+        a: string
+        b: Error
+        c: number[]
+      }
+      const x: SomeDeclaredType = {
+        a: 'alpha',
+        b: new Error('beta'),
+        c: [3]
+      }
+      const result = _.pick(x, ['a'])
+      assert.deepEqual(result, {
+        a: 'alpha'
       })
     })
   })


### PR DESCRIPTION
## Description

I messed up the types on `pick` when I set it to `Record<string, any>`, it currently does not accept interfaces 😞 this PR changes the generic to an object so it can accept other things.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

If the PR resolves an open issue tag it here. For example, `Resolves #34`
