### PR TITLE
fix spelling mistake in clone page

### DIFF
--- a/docs/object/clone.mdx
+++ b/docs/object/clone.mdx
@@ -1,12 +1,12 @@
 ---
 title: clone
-description: Creates a shallow copy of the given obejct/value.
+description: Creates a shallow copy of the given object/value.
 group: Object
 ---
 
 ## Basic usage
 
-Creates a shallow copy of the given obejct/value.
+Creates a shallow copy of the given object/value.
 
 ```ts
 import { clone } from 'radash'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "10.7.1",
+  "version": "10.7.0",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
## Description

Just noticed a small spelling mistake in the clone page

## Checklist

- [✅] Changes are covered by tests if behavior has been changed or added
- [✅] Tests have 100% coverage
- [✅] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [✅] If code changes were made, the documentation (in the `/docs` directory) has been updated

