### PR TITLE
`assign` should keep unique values

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -272,19 +272,21 @@ export const assign = <X extends Record<string | symbol | number, any>>(
   initial: X,
   override: X
 ): X => {
-  if (!initial && !override) return {} as X
-  if (!initial) return override as X
-  if (!override) return initial as X
-  return Object.entries(initial).reduce((acc, [key, value]) => {
-    return {
-      ...acc,
-      [key]: (() => {
-        if (isObject(value)) return assign(value, override[key])
-        // if (isArray(value)) return value.map(x => assign)
-        return override[key]
-      })()
-    }
-  }, {} as X)
+  if (!initial || !override) return initial ?? override ?? {}
+
+  return Object.entries({ ...initial, ...override }).reduce(
+    (acc, [key, value]) => {
+      return {
+        ...acc,
+        [key]: (() => {
+          if (isObject(initial[key])) return assign(initial[key], value)
+          // if (isArray(value)) return value.map(x => assign)
+          return value
+        })()
+      }
+    },
+    {} as X
+  )
 }
 
 /**

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -398,6 +398,14 @@ describe('object module', () => {
       const result = _.assign(initial, override)
       assert.deepEqual(result, override)
     })
+    test('handles initial have unique value', () => {
+      const result = _.assign({ a: 'x' }, {})
+      assert.deepEqual(result, { a: 'x' })
+    })
+    test('handles override have unique value', () => {
+      const result = _.assign({}, { b: 'y' })
+      assert.deepEqual(result, { b: 'y' })
+    })
   })
 
   describe('keys function', () => {


### PR DESCRIPTION
## Description
`assign` should keep unique properties of both object.

[issue reproduction example](https://codesandbox.io/s/radash-assign-lzxw4t?file=/src/index.ts)

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves
Resolves #247 
