### PR TITLE
Fix trim throwing regex error

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -135,6 +135,7 @@ export const trim = (
   charsToTrim: string = ' '
 ) => {
   if (!str) return ''
-  const regex = new RegExp(`^[${charsToTrim}]+|[${charsToTrim}]+$`, 'g')
+  const toTrim = charsToTrim.replace(/[\W]{1}/g, '\\$&')
+  const regex = new RegExp(`^[${toTrim}]+|[${toTrim}]+$`, 'g')
   return str.replace(regex, '')
 }

--- a/src/tests/string.test.ts
+++ b/src/tests/string.test.ts
@@ -185,5 +185,9 @@ describe('string module', () => {
       assert.equal(_.trim('//repos////', '/'), 'repos')
       assert.equal(_.trim('/repos/:owner/:repo/', '/'), 'repos/:owner/:repo')
     })
+
+    test('handles when char to trim is special case in regex', () => {
+      assert.equal(_.trim('_- hello_- ', '_- '), 'hello')
+    })
   })
 })


### PR DESCRIPTION
## Description
JS is throwing error if `charsToTrim` has some special value.
In this example, `trim(" __-_ hello", "_- ")`, `_- ` is treated as a range, but that range is invalid. 
In this PR, every value that is not ascii char, number, or underscore (`\W`) is escaped.
There is maybe better way to do this, I'm not sure.
I'm not sure if this fixes all posibilities, especially with emojis and unicode, I'm not familiar enough.



## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

Resolves #250 
