### PR TITLE
Added warning about default TTL in memo

### DIFF
--- a/docs/curry/memo.mdx
+++ b/docs/curry/memo.mdx
@@ -24,7 +24,7 @@ now === later // => true
 
 ## Expiration
 
-You can optionally pass a `ttl` (time to live) that will expire memoized results.
+You can optionally pass a `ttl` (time to live) that will expire memoized results. In versions prior to version 10, `ttl` had a value of 300 milliseconds if not specified.
 
 ```ts
 import { memo, sleep } from 'radash'


### PR DESCRIPTION
## Description

My web app overloaded my server's bandwidth because network calls weren't being memoized as expected. Upgrading from v9 to v10 fixed it, but I wish the documentation had warned me about the default TTL in old versions.
