### PR TITLE
Docs: Fix typos in tryit.mdx

### DIFF
--- a/docs/async/tryit.mdx
+++ b/docs/async/tryit.mdx
@@ -8,7 +8,7 @@ description: Convert a function to an error-first async function
 
 Error-first callbacks were cool. Using mutable variables to hoist state when doing try/catch was not cool.
 
-The `_.try` function let's you wrap a function to convert it to an error-first async function.
+The `tryit` function let's you wrap a function to convert it to an error-first async function.
 
 ```ts
 import { tryit } from 'radash'
@@ -18,7 +18,7 @@ const [err, user] = await tryit(api.users.find)(userId)
 
 ### Currying
 
-You can curry `try` if you like.
+You can curry `tryit` if you like.
 
 ```ts
 import { tryit } from 'radash'


### PR DESCRIPTION

Fixes a few typos in the `tryit` docs :)