### PR TITLE
Docs: Add link between `sort` and `alphabetical`

### DIFF
--- a/docs/array/alphabetical.mdx
+++ b/docs/array/alphabetical.mdx
@@ -7,8 +7,11 @@ description: Sorts an array of objects alphabetically by a property
 ## Basic usage
 
 Given an array of objects and a callback function used to determine
-the property to use for sorting returns a new array with the objects
-sorted alphabetically.
+the property to use for sorting, return a new array with the objects
+sorted alphabetically. A third, and optional, argument allows you to
+sort in descending order instead of the default ascending order.
+
+For numerical sorting, see the [sort](./sort) function.
 
 ```ts
 import { alphabetical } from 'radash'

--- a/docs/array/sort.mdx
+++ b/docs/array/sort.mdx
@@ -1,12 +1,14 @@
 ---
 title: sort
 group: 'Array'
-description: Sort a list of items by a property
+description: Sort a list of objects by a numerical property
 ---
 
 ## Basic usage
 
-Given an array of items return a new array sorted by the property specified in the get function. A third, and optional, argument allows you to get the sort in descending order.
+Given an array of objects, return a new array sorted by the numerical property specified in the get function. A third, and optional, argument allows you to sort in descending order instead of the default ascending order.
+
+This function only supports numerical sorting. For alphabetic sorting, see the [alphabetical](./alphabetical) function.
 
 ```ts
 import { sort } from 'radash'


### PR DESCRIPTION
## Description

It's quite common to have a single sort function that supports both numerical and alphabetical sorting. Since radash have two different functions (`sort` and `alphabetical`), I think it's useful to provide a link between them in the documentation.

## Checklist

- [-] Changes are covered by tests if behavior has been changed or added
- [-] Tests have 100% coverage
- [-] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [-] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [-] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

Resolves #284