### PR TITLE
docs: fix typo in trim documentation

### DIFF
--- a/docs/string/trim.mdx
+++ b/docs/string/trim.mdx
@@ -13,7 +13,7 @@ import { trim } from 'radash'
 
 trim('  hello ') // => hello
 trim('__hello__', '_') // => hello
-trim('/repos/:owner/', '/') // => repos/:owner/
+trim('/repos/:owner/', '/') // => repos/:owner
 ```
 
 Trim also handles more than one character to trim.


### PR DESCRIPTION
`trim` should remove the '/' at the end as well.