### PR TITLE
fix: replace escape condition on falsy values

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -180,7 +180,7 @@ export const replace = <T>(
   match: (item: T, idx: number) => boolean
 ): T[] => {
   if (!list) return []
-  if (!newItem) return [...list]
+  if (newItem === undefined) return [...list]
   for (let idx = 0; idx < list.length; idx++) {
     const item = list[idx]
     if (match(item, idx)) {

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -176,9 +176,13 @@ describe('array module', () => {
       )
       assert.deepEqual(result, [])
     })
-    test('returns the list for a null new item', () => {
-      const result = _.replace(['a'], null, () => false)
+    test('returns the list for an undefined new item', () => {
+      const result = _.replace(['a'], undefined, () => true)
       assert.deepEqual(result, ['a'])
+    })
+    test('returns replaced item when value is null', () => {
+      const result = _.replace(['a'], null, i => i === 'a')
+      assert.deepEqual(result, [null])
     })
     test('returns replaced item by index', () => {
       const result = _.replace(


### PR DESCRIPTION
## Description

See #258

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

Resolves #258
