### PR TITLE
fix: split number from letters in snake func

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -37,7 +37,12 @@ export const camel = (str: string): string => {
  * snake('va va-VOOM') -> 'va_va_voom'
  * snake('helloWord') -> 'hello_world'
  */
-export const snake = (str: string): string => {
+export const snake = (
+  str: string,
+  options?: {
+    splitOnNumber?: boolean
+  }
+): string => {
   const parts =
     str
       ?.replace(/([A-Z])+/g, capitalize)
@@ -45,9 +50,12 @@ export const snake = (str: string): string => {
       .map(x => x.toLowerCase()) ?? []
   if (parts.length === 0) return ''
   if (parts.length === 1) return parts[0]
-  return parts.reduce((acc, part) => {
+  const result = parts.reduce((acc, part) => {
     return `${acc}_${part.toLowerCase()}`
   })
+  return options?.splitOnNumber === false
+    ? result
+    : result.replace(/([A-Za-z]{1}[0-9]{1})/, val => `${val[0]!}_${val[1]!}`)
 }
 
 /**

--- a/src/tests/string.test.ts
+++ b/src/tests/string.test.ts
@@ -41,6 +41,16 @@ describe('string module', () => {
       const result = _.snake('hello-world')
       assert.equal(result, 'hello_world')
     })
+    test('splits numbers that are next to letters', () => {
+      const result = _.snake('hello-world12_19-bye')
+      assert.equal(result, 'hello_world_12_19_bye')
+    })
+    test('does not split numbers when flag is set to false', () => {
+      const result = _.snake('hello-world12_19-bye', {
+        splitOnNumber: false
+      })
+      assert.equal(result, 'hello_world12_19_bye')
+    })
     test('returns single word', () => {
       const result = _.snake('hello')
       assert.equal(result, 'hello')


### PR DESCRIPTION
## Description

Snake function should turn `hello12` into `hello_12` but it was not. For sake of compatibility also added a flag to keep using the older parsing.

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

Resolves #248 
