### PR TITLE
types: add overload for static array in all func

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radash",
-  "version": "10.9.0",
+  "version": "11.0.0",
   "description": "Functional utility library - modern, simple, typed, powerful",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/async.ts
+++ b/src/async.ts
@@ -162,6 +162,9 @@ type PromiseValues<T extends Promise<any>[]> = {
  *   slack.customerSuccessChannel.sendMessage(...)
  * ])
  */
+export async function all<T extends [Promise<any>, ...Promise<any>[]]>(
+  promises: T
+): Promise<PromiseValues<T>>
 export async function all<T extends Promise<any>[]>(
   promises: T
 ): Promise<PromiseValues<T>>

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -522,7 +522,7 @@ describe('async module', () => {
   describe('_.all', () => {
     const promise = {
       resolve: <T>(value: T) => new Promise<T>(res => res(value)),
-      throw: (err: any) => new Promise((res, rej) => rej(err))
+      reject: (err: any) => new Promise((res, rej) => rej(err))
     }
     it('returns array with values in correct order when given array', async () => {
       const result = await _.all([
@@ -549,7 +549,7 @@ describe('async module', () => {
         await _.all({
           num: promise.resolve(22),
           str: promise.resolve('hello'),
-          err: promise.throw(new Error('broken'))
+          err: promise.reject(new Error('broken'))
         })
       } catch (e: any) {
         const err = e as AggregateError
@@ -564,7 +564,7 @@ describe('async module', () => {
         await _.all([
           promise.resolve(22),
           promise.resolve('hello'),
-          promise.throw(new Error('broken'))
+          promise.reject(new Error('broken'))
         ])
       } catch (e: any) {
         const err = e as AggregateError

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -521,22 +521,22 @@ describe('async module', () => {
 
   describe('_.all', () => {
     const promise = {
-      pass: <T>(value: T) => new Promise<T>(res => res(value)),
-      fail: (err: any) => new Promise((res, rej) => rej(err))
+      resolve: <T>(value: T) => new Promise<T>(res => res(value)),
+      throw: (err: any) => new Promise((res, rej) => rej(err))
     }
     it('returns array with values in correct order when given array', async () => {
       const result = await _.all([
-        promise.pass(22),
-        promise.pass('hello'),
-        promise.pass({ name: 'ray' })
+        promise.resolve(22),
+        promise.resolve('hello'),
+        promise.resolve({ name: 'ray' })
       ])
       assert.deepEqual(result, [22, 'hello', { name: 'ray' }])
     })
     it('returns object with values in correct keys when given object', async () => {
       const result = await _.all({
-        num: promise.pass(22),
-        str: promise.pass('hello'),
-        obj: promise.pass({ name: 'ray' })
+        num: promise.resolve(22),
+        str: promise.resolve('hello'),
+        obj: promise.resolve({ name: 'ray' })
       })
       assert.deepEqual(result, {
         num: 22,
@@ -547,9 +547,9 @@ describe('async module', () => {
     it('throws aggregate error when a single promise fails (in object mode)', async () => {
       try {
         await _.all({
-          num: promise.pass(22),
-          str: promise.pass('hello'),
-          err: promise.fail(new Error('broken'))
+          num: promise.resolve(22),
+          str: promise.resolve('hello'),
+          err: promise.throw(new Error('broken'))
         })
       } catch (e: any) {
         const err = e as AggregateError
@@ -562,9 +562,9 @@ describe('async module', () => {
     it('throws aggregate error when a single promise fails (in array mode)', async () => {
       try {
         await _.all([
-          promise.pass(22),
-          promise.pass('hello'),
-          promise.fail(new Error('broken'))
+          promise.resolve(22),
+          promise.resolve('hello'),
+          promise.throw(new Error('broken'))
         ])
       } catch (e: any) {
         const err = e as AggregateError


### PR DESCRIPTION
## Description

When calling `all` with a static array of promises the return type was a union of the types which was very unhelpful. Added an overload that specifically handles the types for a statically typed array.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

n/a
