### PR TITLE
Make cluster example more clear

### DIFF
--- a/docs/array/cluster.mdx
+++ b/docs/array/cluster.mdx
@@ -13,12 +13,13 @@ split as evenly as possible.
 ```ts
 import { cluster } from 'radash'
 
-const gods = ['Ra', 'Zeus', 'Loki', 'Vishnu', 'Icarus', 'Osiris', 'Thor']
+const gods = ['Ra', 'Zeus', 'Loki', 'Vishnu', 'Icarus', 'Osiris', 'Thor', 'Apollo', 'Artemis', 'Athena']
 
 cluster(gods, 3)
 // => [
 //   [ 'Ra', 'Zeus', 'Loki' ],
 //   [ 'Vishnu', 'Icarus', 'Osiris' ],
-//   [ 'Thor' ]
+//   ['Thor', 'Apollo', 'Artemis'],
+//   ['Athena']
 // ]
 ```


### PR DESCRIPTION
The current cluster example has the same cluster size as a number of clusters in result (3) which could be misleading.  Use bigger array to have cluster size (3) different from number of clusters (4).

