### PR TITLE
docs: mention that `unique` does not preserve order

### DIFF
--- a/docs/array/unique.mdx
+++ b/docs/array/unique.mdx
@@ -8,6 +8,8 @@ description: Remove duplicates from an array
 
 Given an array of items -- and optionally, a function to determine their identity -- return a new array without any duplicates.
 
+The function does not preserve the original order of items.
+
 ```ts
 import { unique } from 'radash'
 


### PR DESCRIPTION
Mention in docs that `unique` doesn't preserve order.