### PR TITLE
Add product function

### DIFF
--- a/docs/array/product.mdx
+++ b/docs/array/product.mdx
@@ -1,0 +1,31 @@
+---
+title: product
+group: 'Array'
+description: Get Cartesian product of the arguments
+---
+
+## Basic usage
+
+```ts
+import { product } from 'radash'
+
+const array1 = [0, 1]
+const array2 = ['a', 'b']
+const array3 = ['A', 'B', 'C']
+
+product(array1, array2, array3) /* => [
+  [0, 'a', 'A'],
+  [0, 'a', 'B'],
+  [0, 'a', 'C'],
+  [0, 'b', 'A'],
+  [0, 'b', 'B'],
+  [0, 'b', 'C'],
+  [1, 'a', 'A'],
+  [1, 'a', 'B'],
+  [1, 'a', 'C'],
+  [1, 'b', 'A'],
+  [1, 'b', 'B'],
+  [1, 'b', 'C'],
+]
+*/
+```

--- a/src/array.ts
+++ b/src/array.ts
@@ -548,3 +548,22 @@ export function shift<T>(arr: Array<T>, n: number) {
 
   return [...arr.slice(-shiftNumber, arr.length), ...arr.slice(0, -shiftNumber)]
 }
+
+export type ProductItem<Arrs> = Arrs extends [Array<infer T>, ...infer Rest] ? Rest extends [] ? [T] : [T, ...ProductItem<Rest>] : never;
+export function product<T extends Array<any>[]>(...args: T): Array<ProductItem<T>> {
+  if (args.some(arg => arg.length < 1)) return [];
+  const indices = new Array(args.length).fill(0);
+  let currentIndex = args.length - 1;
+  const result = [] as Array<T[number][number]>;
+  while (indices[0] < args[0]?.length) {
+    result.push(indices.map((j, i) => args[i][j]));
+    indices[currentIndex] += 1;
+    while (currentIndex > 0 && indices[currentIndex] === args[currentIndex].length) {
+      indices[currentIndex] = 0;
+      indices[currentIndex - 1] += 1;
+      currentIndex -= 1;
+    }
+    currentIndex = args.length - 1;
+  }
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
   merge,
   min,
   objectify,
+  product,
+  ProductItem,
   range,
   replace,
   replaceOrAppend,

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -777,4 +777,60 @@ describe('array module', () => {
       assert.deepEqual(result, ['b', 'a'])
     })
   })
+
+  describe('product function', () => {
+    const arrA = [{}, {}, {}]
+    const arrB = [{}, {}]
+    const arrC = [{}]
+    test('returns cartesian product of two arguments', () => {
+      const result = _.product(arrA, arrB)
+      assert.deepEqual(result, [
+        [arrA[0], arrB[0]],
+        [arrA[0], arrB[1]],
+        [arrA[1], arrB[0]],
+        [arrA[1], arrB[1]],
+        [arrA[2], arrB[0]],
+        [arrA[2], arrB[1]],
+      ])
+    })
+    test('returns cartesian product of more than two arguments', () => {
+      const result = _.product(arrB, arrB, arrB)
+      assert.deepEqual(result, [
+        [arrB[0], arrB[0], arrB[0]],
+        [arrB[0], arrB[0], arrB[1]],
+        [arrB[0], arrB[1], arrB[0]],
+        [arrB[0], arrB[1], arrB[1]],
+        [arrB[1], arrB[0], arrB[0]],
+        [arrB[1], arrB[0], arrB[1]],
+        [arrB[1], arrB[1], arrB[0]],
+        [arrB[1], arrB[1], arrB[1]],
+      ])
+    })
+    test('works when one of the arguments has 1 item', () => {
+      const result = _.product(arrB, arrC, arrB)
+      assert.deepEqual(result, [
+        [arrB[0], arrC[0], arrB[0]],
+        [arrB[0], arrC[0], arrB[1]],
+        [arrB[1], arrC[0], arrB[0]],
+        [arrB[1], arrC[0], arrB[1]],
+      ])
+    })
+    test('works when called with a single argument', () => {
+      const result = _.product(arrA)
+      assert.deepEqual(result, [
+        [arrA[0]],
+        [arrA[1]],
+        [arrA[2]],
+      ])
+    })
+    test('returns empty array when one of the arguments is an empty array', () => {
+      const result = _.product(arrA, [], arrB)
+      assert.deepEqual(result, [])
+    })
+    test('returns empty array when called with no arguments', () => {
+      const result = _.product()
+      assert.deepEqual(result, [])
+    })
+  })
+
 })


### PR DESCRIPTION
## Description

This PR adds a product function that takes N arrays as arguments and outputs the Cartesian product, for example:
```ts
produce(['a', 'b'], [1, 2]) // => [['a', 1], ['a', 2], ['b', 1], ['b', 2]]
```

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [x] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

If the PR resolves an open issue tag it here. For example, `Resolves #34`
