### PR TITLE
Update throttle visualization

### DIFF
--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -33,7 +33,7 @@ the given callback after `interval` milliseconds have passed.
 
 ```sh
                 Time: 0ms - - - - 100ms - - - - 200ms - - - - 300ms - - - - 400ms - - - -
-Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x - - -
+Throttle Invocations: x x x x x x x x x x x x x x x x x - - - - - - - - - - - - - - - - -
   Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
 ```
 


### PR DESCRIPTION
## Description

The visualization of `throttle` doesn't make clear that there will be a final source invocation at 600ms. This lead to some confusion on my team, so I'm suggesting an alternate visualization that includes a final source invocation after the last throttled invocation.

## Checklist

N/A
- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [x] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [x] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

N/A