### PR TITLE
feat: Add jitter function.

### DIFF
--- a/docs/random/jitter.mdx
+++ b/docs/random/jitter.mdx
@@ -1,0 +1,24 @@
+---
+title: jitter
+description: Get a randomized delay from the input delay and jitter factor.
+group: 'Random'
+---
+
+## Basic usage
+
+The function takes two parameters: `delay` (base delay in milliseconds) and an optional `factor` (jitter factor, default `0.2`), meaning the final delay varies by `±20%`.
+
+The jitter factor can be adjusted as needed; a value between `0.1` and `0.5` is generally recommended. Setting it too big (for example, greater than `1`) may cause unintended or unexpected behavior.
+
+```ts
+import { jitter } from 'radash'
+
+jitter(1000) // => value in [800, 1200] (default factor 0.2)
+jitter(1000, 0.5) // => value in [500, 1500]
+jitter(1000, 0) // => 1000
+
+jitter(-50) // => 0
+jitter(1000, NaN) // factor treated as 0 => ~1000
+```
+
+This function uses `return Math.max(0, delay + jitter)` to ensure that when in some extreme cases like: `delay` value given is very small, but `factor` given is big and the `random` is `-1`, the result would not be negative, which in turns prevents the unexpected behavior by returning `0` when this happens.

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export {
   shake,
   upperize
 } from './object'
-export { draw, random, shuffle, uid } from './random'
+export { draw, jitter, random, shuffle, uid } from './random'
 export { series } from './series'
 export {
   camel,

--- a/src/random.ts
+++ b/src/random.ts
@@ -38,3 +38,10 @@ export const uid = (length: number, specials: string = '') => {
     ''
   )
 }
+
+export const jitter = (delay: number, factor = 0.2): number => {
+  if (!Number.isFinite(delay) || delay < 0) return 0
+  if (!Number.isFinite(factor) || factor < 0) factor = 0
+  const jitter = delay * factor * random(-1, 1)
+  return Math.max(0, delay + jitter)
+}

--- a/src/tests/random.test.ts
+++ b/src/tests/random.test.ts
@@ -77,3 +77,72 @@ describe('random module', () => {
     })
   })
 })
+
+describe('jitter', () => {
+  it('returns the base delay when factor is 0', () => {
+    const delay = 1000
+    for (let i = 0; i < 5; i++) {
+      const result = _.jitter(delay, 0)
+      assert.strictEqual(result, delay)
+    }
+  })
+
+  it('returns a value within the expected jitter range', () => {
+    const delay = 1000
+    const factor = 0.3
+    // Expected range: [700, 1300]
+    for (let i = 0; i < 20; i++) {
+      const result = _.jitter(delay, factor)
+      assert.ok(result >= 700 && result <= 1300, `Got ${result}`)
+    }
+  })
+
+  it('never returns a negative value', () => {
+    for (let i = 0; i < 10; i++) {
+      const result = _.jitter(0, 1)
+      assert.ok(result >= 0)
+    }
+  })
+
+  it('uses default factor 0.2 when not provided', () => {
+    const delay = 1000
+    // Expected range: [800, 1200]
+    for (let i = 0; i < 10; i++) {
+      const result = _.jitter(delay)
+      assert.ok(result >= 800 && result <= 1200, `Got ${result}`)
+    }
+  })
+
+  it('returns 0 for negative delay', () => {
+    const result = _.jitter(-100, 0.5)
+    assert.strictEqual(result, 0)
+  })
+
+  it('returns 0 for NaN delay', () => {
+    const result = _.jitter(NaN, 0.5)
+    assert.strictEqual(result, 0)
+  })
+
+  it('returns 0 for Infinity delay', () => {
+    const result = _.jitter(Infinity, 0.5)
+    assert.strictEqual(result, 0)
+  })
+
+  it('treats negative factor as 0', () => {
+    const delay = 1000
+    const result = _.jitter(delay, -0.5)
+    assert.strictEqual(result, delay)
+  })
+
+  it('treats NaN factor as 0', () => {
+    const delay = 1000
+    const result = _.jitter(delay, NaN)
+    assert.strictEqual(result, delay)
+  })
+
+  it('treats Infinity factor as 0', () => {
+    const delay = 1000
+    const result = _.jitter(delay, Infinity)
+    assert.ok(result >= 0)
+  })
+})


### PR DESCRIPTION
## Description

This PR introduces a new `jitter` function to the random utilities. The `jitter` function returns a randomized delay based on a given base `delay` and an optional jitter `factor`, allowing the delay to vary within a specified range (default ±20%). This is useful for scenarios where randomized timing is needed, such as retry backoffs or distributed systems. The implementation ensures the result is never negative, even in edge cases.

Documentation for the new function has been added under `jitter.mdx`, and comprehensive tests have been included to cover all expected behaviors and edge cases.

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [x] If code changes were made, the documentation (in the `/docs` directory) has been updated

**I'm not sure if my PR will be accepted and merged. To ensure the rigor of the project, I have not modified the version in package.json or run yarn build. If this pull request is eventually merged, I will make the remaining two changes in the Checklist.**
